### PR TITLE
Use Anki stats for streak calculation

### DIFF
--- a/pet_widget.py
+++ b/pet_widget.py
@@ -17,7 +17,7 @@ class PetWidget(QWidget):
         self.image.setGeometry(100, 60, 100, 100)
 
         self.status = QLabel(self)
-        self.status.setGeometry(10, 160, 280, 30)
+        self.status.setGeometry(10, 150, 280, 80)
         self.status.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.animations = {


### PR DESCRIPTION
## Summary
- compute pet streak using Anki's revlog data
- penalize missed days only when no study activity according to revlog
- expand status panel so hunger stat is visible

## Testing
- `python -m py_compile pet.py`
- `python -m py_compile pet_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae52a2a3d0832fb978f88bb64123fc