### PR TITLE
Use Anki stats for streak calculation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -9,10 +9,18 @@ from PyQt6.QtWidgets import QDockWidget
 from PyQt6.QtCore import Qt
 import os
 
-pet = AnkiPet()
+pet = None
 pet_widget = None
 
+
+def init_pet() -> None:
+    """Initialize the pet after a profile has been opened."""
+    global pet
+    pet = AnkiPet()
+
 def on_card_review(reviewer, card, ease):
+    if pet is None:
+        return
     today = datetime.now().date()
     if ease > 1:
         pet.feed()
@@ -27,12 +35,15 @@ def on_card_review(reviewer, card, ease):
 
 def show_pet():
     global pet_widget
+    if pet is None:
+        return
     today = datetime.now().date()
     pet.check_streak(today)
     pet_widget = PetWidget(pet, os.path.dirname(__file__))
     dock = QDockWidget("AnkiPet", parent=mw)
     dock.setWidget(pet_widget)
     mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock)
-
+ 
+gui_hooks.profile_did_open.append(init_pet)
 gui_hooks.main_window_did_init.append(show_pet)
 gui_hooks.reviewer_did_answer_card.append(on_card_review)

--- a/pet.py
+++ b/pet.py
@@ -1,11 +1,14 @@
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from aqt import mw
 
 class AnkiPet:
     def __init__(self):
-        # Load persisted stats if available
-        saved = mw.pm.profile.get("ankipet_stats", {})
+        # Load persisted stats if available. ``mw.pm.profile`` is not available
+        # until a profile has been opened, so guard against ``None`` to avoid
+        # crashes when the add-on is imported before that happens.
+        profile = getattr(mw.pm, "profile", None) if getattr(mw, "pm", None) else None
+        saved = profile.get("ankipet_stats", {}) if profile else {}
         self.happiness = saved.get("happiness", 100)
         self.hunger = saved.get("hunger", 0)
         self.health = saved.get("health", 100)
@@ -15,7 +18,8 @@ class AnkiPet:
         self.last_active_day = self.load_last_active_day()
 
     def load_last_active_day(self):
-        saved = mw.pm.profile.get("ankipet_last_active")
+        profile = getattr(mw.pm, "profile", None) if getattr(mw, "pm", None) else None
+        saved = profile.get("ankipet_last_active") if profile else None
         if saved:
             try:
                 return datetime.strptime(saved, "%Y-%m-%d").date()
@@ -24,18 +28,22 @@ class AnkiPet:
         return None
 
     def save_last_active_day(self, day):
-        mw.pm.profile["ankipet_last_active"] = day.strftime("%Y-%m-%d")
-        mw.pm.save()
+        profile = getattr(mw.pm, "profile", None) if getattr(mw, "pm", None) else None
+        if profile:
+            profile["ankipet_last_active"] = day.strftime("%Y-%m-%d")
+            mw.pm.save()
 
     def save_stats(self):
-        mw.pm.profile["ankipet_stats"] = {
-            "happiness": self.happiness,
-            "hunger": self.hunger,
-            "health": self.health,
-            "level": self.level,
-            "streak": self.streak,
-        }
-        mw.pm.save()
+        profile = getattr(mw.pm, "profile", None) if getattr(mw, "pm", None) else None
+        if profile:
+            profile["ankipet_stats"] = {
+                "happiness": self.happiness,
+                "hunger": self.hunger,
+                "health": self.health,
+                "level": self.level,
+                "streak": self.streak,
+            }
+            mw.pm.save()
 
     def feed(self):
         self.hunger = max(0, self.hunger - 10)
@@ -53,18 +61,43 @@ class AnkiPet:
         self.save_stats()
 
     def check_streak(self, today):
+        # Determine the current streak based on Anki's revlog rather than
+        # the plugin's stored state. Anki stores all review activity in the
+        # ``revlog`` table, and ``day_cutoff`` marks the start of the next day
+        # according to the collection's settings. By grouping the revlog entries
+        # by their distance from ``day_cutoff`` we can count how many consecutive
+        # days have had study activity, starting from today.
+
+        day_cutoff = mw.col.sched.day_cutoff
+        days = mw.col.db.list(
+            """
+select cast((? - id/1000) / 86400 as int) as day
+from revlog
+group by day
+""",
+            day_cutoff,
+        )
+        day_set = set(days)
+        streak = 0
+        while streak in day_set:
+            streak += 1
+        self.streak = streak
+
+        # Apply penalties for full days without any study activity. We only
+        # penalize days that have fully elapsed (yesterday and earlier) and
+        # avoid double‑counting by tracking the last day already handled.
+        yesterday = today - timedelta(days=1)
         if self.last_active_day is None:
-            self.streak = 1
+            self.last_active_day = yesterday if 0 not in day_set else today
         else:
-            days_missed = (today - self.last_active_day).days
-            if days_missed == 1:
-                self.streak += 1
-            elif days_missed > 1:
-                self.streak = 1
-                missed = days_missed - 1
+            if yesterday > self.last_active_day:
+                missed = (yesterday - self.last_active_day).days
                 self.health = max(0, self.health - (missed * 10))
                 self.happiness = max(0, self.happiness - (missed * 5))
                 self.hunger = min(100, self.hunger + (missed * 10))
-        self.last_active_day = today
-        self.save_last_active_day(today)
+                self.last_active_day = self.last_active_day + timedelta(days=missed)
+            if 0 in day_set:
+                self.last_active_day = today
+
+        self.save_last_active_day(self.last_active_day)
         self.save_stats()

--- a/pet_widget.py
+++ b/pet_widget.py
@@ -11,13 +11,13 @@ class PetWidget(QWidget):
         self.base_dir = base_dir
         self.frame_index = 0
         self.animation_timer = QTimer(self)
-        self.setFixedSize(300, 200)
+        self.setFixedSize(320, 270)
 
         self.image = QLabel(self)
-        self.image.setGeometry(100, 60, 100, 100)
+        self.image.setGeometry(110, 60, 100, 100)
 
         self.status = QLabel(self)
-        self.status.setGeometry(10, 160, 280, 30)
+        self.status.setGeometry(10, 180, 300, 90)
         self.status.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.animations = {
@@ -31,7 +31,7 @@ class PetWidget(QWidget):
         self.load_animation(self.current_animation)
         self.update_status()
 
-        self.position_x = 100
+        self.position_x = 110
         self.moving_right = True
         self.facing_right = True
 
@@ -86,7 +86,7 @@ class PetWidget(QWidget):
         if self.current_animation == "walk":
             if self.moving_right:
                 self.position_x += 4
-                if self.position_x > 200:
+                if self.position_x > self.width() - 100:
                     self.moving_right = False
             else:
                 self.position_x -= 4


### PR DESCRIPTION
## Summary
- compute pet streak using Anki's revlog data
- penalize missed days only when no study activity according to revlog
- expand status panel so hunger stat is visible
- initialize pet after profile opens and guard profile access to avoid startup crash
- enlarge pet widget frame so streak stat is visible

## Testing
- `python -m py_compile __init__.py pet.py pet_widget.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae52a2a3d0832fb978f88bb64123fc